### PR TITLE
suggest language changes, order of arguments

### DIFF
--- a/contracts/UportRegistry.sol
+++ b/contracts/UportRegistry.sol
@@ -1,30 +1,48 @@
+// Copyright (C) 2016, 2017  ConsenSys, Inc
+// Copyright (C) 2017        DappHub, LLC
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 pragma solidity 0.4.8;
 
 contract UportRegistry {
   uint public version;
-  address public previousPublishedVersion;
-  mapping(address => mapping(address => mapping(bytes32 => bytes32))) public registry;
+  address public lastVersion;
+  mapping(address=>
+    mapping(address=>
+      mapping(bytes32=>
+        bytes32))) public registry;
 
-  function UportRegistry(address _previousPublishedVersion) {
+  function UportRegistry(address _lastVersion) {
     version = 3;
-    previousPublishedVersion = _previousPublishedVersion;
+    lastVersion = _lastVersion;
   }
 
   event Set (
-    address indexed from,
-    address indexed to,
+    address indexed src,
+    address indexed dst,
     bytes32 indexed key,
-    bytes32         value,
-    uint256         updatedAt
-  );
+    bytes32 indexed val,
+    uint256         tau
+  ) anonymous;
 
   //create or update
-  function set(address to, bytes32 key, bytes32 value) {
-      Set(msg.sender, to, key, value, now);
-      registry[msg.sender][to][key] = value;
+  function set(address dst, bytes32 key, bytes32 val) {
+      Set(msg.sender, dst, key, val, now);
+      registry[msg.sender][dst][key] = val;
   }
 
-  function get(address from, address to, bytes32 key) constant returns(bytes32) {
-      return registry[from][to][key];
+  function get(address src, address dst, bytes32 key) constant returns (bytes32 val) {
+      return registry[src][dst][key];
   }
 }

--- a/contracts/UportRegistry.sol
+++ b/contracts/UportRegistry.sol
@@ -3,7 +3,7 @@ pragma solidity 0.4.8;
 contract UportRegistry {
   uint public version;
   address public previousPublishedVersion;
-  mapping(address => mapping(bytes32 => mapping(bytes32 => bytes32))) public registry;
+  mapping(address => mapping(address => mapping(bytes32 => bytes32))) public registry;
 
   function UportRegistry(address _previousPublishedVersion) {
     version = 3;

--- a/contracts/UportRegistry.sol
+++ b/contracts/UportRegistry.sol
@@ -1,28 +1,30 @@
 pragma solidity 0.4.8;
 
-contract UportRegistry{
+contract UportRegistry {
   uint public version;
   address public previousPublishedVersion;
-  mapping(bytes32 => mapping(address => mapping(address => bytes32))) public registry;
+  mapping(address => mapping(bytes32 => mapping(bytes32 => bytes32))) public registry;
 
   function UportRegistry(address _previousPublishedVersion) {
     version = 3;
     previousPublishedVersion = _previousPublishedVersion;
   }
 
-  event Set(
-    bytes32 indexed registrationIdentifier,
-    address indexed issuer,
-    address indexed subject,
-    uint updatedAt);
+  event Set (
+    address indexed from,
+    address indexed to,
+    bytes32 indexed key,
+    bytes32         value,
+    uint256         updatedAt
+  );
 
   //create or update
-  function set(bytes32 registrationIdentifier, address subject, bytes32 value){
-      Set(registrationIdentifier, msg.sender, subject, now);
-      registry[registrationIdentifier][msg.sender][subject] = value;
+  function set(address to, bytes32 key, bytes32 value) {
+      Set(msg.sender, to, key, value, now);
+      registry[msg.sender][to][key] = value;
   }
 
-  function get(bytes32 registrationIdentifier, address issuer, address subject) constant returns(bytes32){
-      return registry[registrationIdentifier][issuer][subject];
+  function get(address from, address to, bytes32 key) constant returns(bytes32) {
+      return registry[from][to][key];
   }
 }


### PR DESCRIPTION
at dapphub we're taking a look at this, we've wanted something like this forever. This PR is some suggested changes, the most important one is changing the argument order, purely for aesthetic / usability reasons. The concept of `registrationIdentifier` is replaced with a `key`, as in simple key-value pairs you can write "about" anyone.

open issues:
* `from`/`to` could have clearer names (but I prefer this graph analogy over `issuer` and `subject`)
* put APL in the source? Good for when contract source file is uploaded to explorers